### PR TITLE
Add didcomm stubs

### DIFF
--- a/packages/jose/src/didcomm.ts
+++ b/packages/jose/src/didcomm.ts
@@ -1,0 +1,22 @@
+import CompactEncrypt from 'jose/jwe/compact/encrypt'
+import compactDecrypt from 'jose/jwe/compact/decrypt'
+import parseJwk from 'jose/jwk/parse'
+
+const JWE_ALG = 'ECDH-ES'
+const JWE_ENC = 'A256GCM'
+
+export const encrypt = async (payload: string, publicKeyJwk: any) => {
+  const ecPublicKey = await parseJwk(publicKeyJwk, JWE_ALG)
+  const encoder = new TextEncoder()
+  const jwe = await new CompactEncrypt(encoder.encode(payload))
+    //
+    .setProtectedHeader({alg: JWE_ALG, enc: JWE_ENC})
+    .encrypt(ecPublicKey)
+  return jwe
+}
+
+export const decrypt = async (jwe: string, privateKeyJwk: any) => {
+  const ecPrivateKey = await parseJwk(privateKeyJwk, JWE_ALG)
+  const {plaintext} = await compactDecrypt(jwe, ecPrivateKey)
+  return Buffer.from(plaintext).toString()
+}

--- a/packages/jose/src/index.ts
+++ b/packages/jose/src/index.ts
@@ -4,6 +4,8 @@ import jwtVerify, {JWTVerifyGetKey, JWTVerifyOptions} from 'jose/jwt/verify'
 import {JWTVerifyResult, SignOptions} from 'jose/webcrypto/types'
 import {JWTClaimValidationFailed, JWTInvalid} from 'jose/webcrypto/util/errors'
 
+export * as didcomm from './didcomm'
+
 type OmitChallengePayloadFields<Payload> = Omit<Payload, 'jti' | 'iss' | 'aud' | 'purpose'>
 
 type OmitResponsePayloadFields<Payload> = Omit<Payload, 'iss' | 'aud'>

--- a/packages/jose/test/ghp/README.md
+++ b/packages/jose/test/ghp/README.md
@@ -1,0 +1,3 @@
+# Holder to Verifier
+
+Presentation of vaccination certificate.

--- a/packages/jose/test/ghp/fixtures/cm-0.json
+++ b/packages/jose/test/ghp/fixtures/cm-0.json
@@ -1,0 +1,59 @@
+{
+  "locale": "en-US",
+  "issuer": {
+    "id": "did:example:123",
+    "name": "Vaccination Certificate Provider",
+    "styles": {
+      "thumbnail": {
+        "uri": "https://cdn.pixabay.com/photo/2016/09/16/19/16/hearth-1674896_1280.png",
+        "alt": "issuer logo"
+      },
+      "hero": {
+        "uri": "https://cdn.pixabay.com/photo/2016/11/30/12/17/cells-1872666_1280.jpg",
+        "alt": "issuer background"
+      },
+      "background": {
+        "color": "#ff0000"
+      },
+      "text": {
+        "color": "#d4d400"
+      }
+    }
+  },
+  "credential": {
+    "schema": "https://w3id.org/vaccination/#VaccinationCertificate",
+    "display": {
+      "title": {
+        "text": "COVID-19 Vaccination Certificate"
+      },
+      "subtitle": {
+        "text": "COVID-19 Vaccination Certificate"
+      },
+      "description": {
+        "text": "COVID-19 Vaccination Certificate"
+      },
+      "properties": [
+        {
+          "label": "COVID-19 Vaccine Moderna"
+        }
+      ]
+    },
+    "styles": {
+      "thumbnail": {
+        "uri": "https://cdn.pixabay.com/photo/2016/09/16/19/16/hearth-1674896_1280.png",
+        "alt": "credential logo"
+      },
+      "hero": {
+        "uri": "https://cdn.pixabay.com/photo/2016/11/30/12/17/cells-1872666_1280.jpg",
+        "alt": "credential background"
+      },
+      "background": {
+        "color": "#ff0000"
+      },
+      "text": {
+        "color": "#d4d400"
+      }
+    }
+  },
+  "presentation_definition": {}
+}

--- a/packages/jose/test/ghp/fixtures/expected-request.json
+++ b/packages/jose/test/ghp/fixtures/expected-request.json
@@ -1,0 +1,33 @@
+{
+  "@type": "https://didcomm.org/present-proof/2.0/request-presentation",
+  "@id": "0ac534c8-98ed-4fe3-8a41-3600775e1e92",
+  "comment": "A verifier is requesting proof of vaccination.",
+  "formats": [{"attach_id": "ed7d9b1f-9eed-4bde-b81c-3aa7485cf947", "format": "dif/presentation-exchange/definitions@v1.0"}],
+  "request_presentations~attach": [
+    {
+      "@id": "ed7d9b1f-9eed-4bde-b81c-3aa7485cf947",
+      "mime-type": "application/json",
+      "data": {
+        "json": {
+          "challenge": "23516943-1d79-4ebd-8981-623f036365ef",
+          "domain": "airline.example/VaccinationCertificate",
+          "presentation_definitions": {
+            "input_descriptors": [
+              {
+                "id": "vaccination_input",
+                "name": "Vaccinatin Certificate",
+                "schema": "https://w3id.org/vaccination/#VaccinationCertificate",
+                "constraints": {
+                  "fields": [
+                    {"path": ["$.credentialSubject.batchNumber"], "filter": {"type": "string"}},
+                    {"path": ["$.credentialSubject.countryOfVaccination"], "filter": {"type": "string"}}
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/jose/test/ghp/fixtures/expected-submission.json
+++ b/packages/jose/test/ghp/fixtures/expected-submission.json
@@ -1,0 +1,57 @@
+{
+  "@type": "https://didcomm.org/present-proof/2.0/presentation",
+  "@id": "f1ca8245-ab2d-4d9c-8d7d-94bf310314ef",
+  "comment": "A holder is presenting proof of vaccination",
+  "formats": [{"attach_id": "2a3f1c4c-623c-44e6-b159-179048c51260", "format": "dif/presentation-exchange/submission@v1.0"}],
+  "presentations~attach": [
+    {
+      "@id": "2a3f1c4c-623c-44e6-b159-179048c51260",
+      "mime-type": "application/ld+json",
+      "data": {
+        "json": {
+          "@context": ["https://www.w3.org/2018/credentials/v1"],
+          "type": ["VerifiablePresentation"],
+          "verifiableCredential": [
+            {
+              "@context": ["https://www.w3.org/2018/credentials/v1", "https://w3id.org/vaccination/v1", "https://w3id.org/security/bbs/v1"],
+              "id": "urn:uvci:af5vshde843jf831j128fj",
+              "type": ["VaccinationCertificate", "VerifiableCredential"],
+              "description": "COVID-19 Vaccination Certificate",
+              "name": "COVID-19 Vaccination Certificate",
+              "expirationDate": "2029-12-03T12:19:52Z",
+              "issuanceDate": "2019-12-03T12:19:52Z",
+              "issuer": "did:key:zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2",
+              "credentialSubject": {
+                "id": "urn:bnid:_:c14n2",
+                "type": "VaccinationEvent",
+                "batchNumber": "1183738569",
+                "countryOfVaccination": "NZ"
+              },
+              "proof": {
+                "type": "BbsBlsSignatureProof2020",
+                "created": "2021-02-18T23:04:28Z",
+                "nonce": "JNGovx4GGoi341v/YCTcZq7aLWtBtz8UhoxEeCxZFevEGzfh94WUSg8Ly/q+2jLqzzY=",
+                "proofPurpose": "assertionMethod",
+                "proofValue": "AB0GQA//jbDwMgaIIJeqP3fRyMYi6WDGhk0JlGJc/sk4ycuYGmyN7CbO4bA7yhIW/YQbHEkOgeMy0QM+usBgZad8x5FRePxfo4v1dSzAbJwWjx87G9F1lAIRgijlD4sYni1LhSo6svptDUmIrCAOwS2raV3G02mVejbwltMOo4+cyKcGlj9CzfjCgCuS1SqAxveDiMKGAAAAdJJF1pO6hBUGkebu/SMmiFafVdLvFgpMFUFEHTvElUQhwNSp6vxJp6Rs7pOVc9zHqAAAAAI7TJuDCf7ramzTo+syb7Njf6ExD11UKNcChaeblzegRBIkg3HoWgwR0hhd4z4D5/obSjGPKpGuD+1DoyTZhC/wqOjUZ03J1EtryZrC+y1DD14b4+khQVLgOBJ9+uvshrGDbu8+7anGezOa+qWT0FopAAAAEG6p07ghODpi8DVeDQyPwMY/iu2Lh7x3JShWniQrewY2GbsACBYOPlkNNm/qSExPRMe2X7UPpdsxpUDwqbObye4EXfAabgKd9gCmj2PNdvcOQAi5rIuJSGa4Vj7AtKoW/2vpmboPoOu4IEM1YviupomCKOzhjEuOof2/y5Adfb8JUVidWqf9Ye/HtxnzTu0HbaXL7jbwsMNn5wYfZuzpmVQgEXss2KePMSkHcfScAQNglnI90YgugHGuU+/DQcfMoA0+JviFcJy13yERAueVuzrDemzc+wJaEuNDn8UiTjAdVhLcgnHqUai+4F6ONbCfH2B3ohB3hSiGB6C7hDnEyXFOO9BijCTHrxPv3yKWNkks+3JfY28m+3NO0e2tlyH71yDX0+F6U388/bvWod/u5s3MpaCibTZEYoAc4sm4jW03HFYMmvYBuWOY6rGGOgIrXxQjx98D0macJJR7Hkh7KJhMkwvtyI4MaTPJsdJGfv8I+RFROxtRM7RcFpa4J5wF/wQnpyorqchwo6xAOKYFqCqKvI9B6Y7Da7/0iOiWsjs8a4zDiYynfYavnz6SdxCMpHLgplEQlnntqCb8C3qly2s5Ko3PGWu4M8Dlfcn4TT8YenkJDJicA91nlLaE8TJbBgsvgyT+zlTsRSXlFzQc+3KfWoODKZIZqTBaRZMft3S/",
+                "verificationMethod": "did:key:zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2#zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2"
+              }
+            }
+          ],
+          "proof": {
+            "type": "Ed25519Signature2018",
+            "proofPurpose": "authentication",
+            "verificationMethod": "did:key:z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL#z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL",
+            "created": "2021-04-23T16:04:37.759497",
+            "challenge": "1f44d55f-f161-4938-a659-f8026467f126",
+            "jws": "eyJhbGciOiAiRWREU0EiLCAiYjY0IjogZmFsc2UsICJjcml0IjogWyJiNjQiXX0..qljm3LhN5vL-qv-4j3Hz6dF7Wgnx8boBAWJONrRAQNmvhBwUkI2_AEvDSbtNNTskz4i8vzzvLX4Ixl75RdoZCQ"
+          },
+          "presentation_submission": {
+            "id": "f9513f33-4ad4-4359-af91-783e052b5ed8",
+            "definition_id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+            "descriptor_map": [{"id": "citizenship_input_1", "format": "ldp_vp", "path": "$.verifiableCredential[0]"}]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/jose/test/ghp/fixtures/index.ts
+++ b/packages/jose/test/ghp/fixtures/index.ts
@@ -1,0 +1,10 @@
+export const presentationDefinition = require('./pd-0.json')
+export const credentialManifest = require('./cm-0.json')
+credentialManifest.presentation_definition = presentationDefinition
+export const request_vp = require('./m0.json')
+request_vp['request_presentations~attach'][0].data.json.presentation_definitions = presentationDefinition
+export const submit_vp = require('./m1.json')
+export const vp = require('./vp.json')
+submit_vp['presentations~attach'][0].data.json = vp
+export const vc = require('./vc-1.json')
+vp.verifiableCredential = [vc]

--- a/packages/jose/test/ghp/fixtures/m0.json
+++ b/packages/jose/test/ghp/fixtures/m0.json
@@ -1,0 +1,24 @@
+{
+  "@type": "https://didcomm.org/present-proof/2.0/request-presentation",
+  "@id": "0ac534c8-98ed-4fe3-8a41-3600775e1e92",
+  "comment": "A verifier is requesting proof of vaccination.",
+  "formats": [
+    {
+      "attach_id": "ed7d9b1f-9eed-4bde-b81c-3aa7485cf947",
+      "format": "dif/presentation-exchange/definitions@v1.0"
+    }
+  ],
+  "request_presentations~attach": [
+    {
+      "@id": "ed7d9b1f-9eed-4bde-b81c-3aa7485cf947",
+      "mime-type": "application/json",
+      "data": {
+        "json": {
+          "challenge": "23516943-1d79-4ebd-8981-623f036365ef",
+          "domain": "airline.example/VaccinationCertificate",
+          "presentation_definitions": {}
+        }
+      }
+    }
+  ]
+}

--- a/packages/jose/test/ghp/fixtures/m1.json
+++ b/packages/jose/test/ghp/fixtures/m1.json
@@ -1,0 +1,20 @@
+{
+  "@type": "https://didcomm.org/present-proof/2.0/presentation",
+  "@id": "f1ca8245-ab2d-4d9c-8d7d-94bf310314ef",
+  "comment": "A holder is presenting proof of vaccination",
+  "formats": [
+    {
+      "attach_id": "2a3f1c4c-623c-44e6-b159-179048c51260",
+      "format": "dif/presentation-exchange/submission@v1.0"
+    }
+  ],
+  "presentations~attach": [
+    {
+      "@id": "2a3f1c4c-623c-44e6-b159-179048c51260",
+      "mime-type": "application/ld+json",
+      "data": {
+        "json": {}
+      }
+    }
+  ]
+}

--- a/packages/jose/test/ghp/fixtures/pd-0.json
+++ b/packages/jose/test/ghp/fixtures/pd-0.json
@@ -1,0 +1,25 @@
+{
+  "input_descriptors": [
+    {
+      "id": "vaccination_input",
+      "name": "Vaccinatin Certificate",
+      "schema": "https://w3id.org/vaccination/#VaccinationCertificate",
+      "constraints": {
+        "fields": [
+          {
+            "path": ["$.credentialSubject.batchNumber"],
+            "filter": {
+              "type": "string"
+            }
+          },
+          {
+            "path": ["$.credentialSubject.countryOfVaccination"],
+            "filter": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/jose/test/ghp/fixtures/vc-0.json
+++ b/packages/jose/test/ghp/fixtures/vc-0.json
@@ -1,0 +1,38 @@
+{
+  "@context": ["https://www.w3.org/2018/credentials/v1", "https://w3id.org/vaccination/v1", "https://w3id.org/security/bbs/v1"],
+  "type": ["VerifiableCredential", "VaccinationCertificate"],
+  "id": "urn:uvci:af5vshde843jf831j128fj",
+  "name": "COVID-19 Vaccination Certificate",
+  "description": "COVID-19 Vaccination Certificate",
+  "issuanceDate": "2019-12-03T12:19:52Z",
+  "expirationDate": "2029-12-03T12:19:52Z",
+  "issuer": "did:key:zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2",
+  "credentialSubject": {
+    "type": "VaccinationEvent",
+    "batchNumber": "1183738569",
+    "administeringCentre": "MoH",
+    "healthProfessional": "MoH",
+    "countryOfVaccination": "NZ",
+    "recipient": {
+      "type": "VaccineRecipient",
+      "givenName": "JOHN",
+      "familyName": "SMITH",
+      "gender": "Male",
+      "birthDate": "1958-07-17"
+    },
+    "vaccine": {
+      "type": "Vaccine",
+      "disease": "COVID-19",
+      "atcCode": "J07BX03",
+      "medicinalProductName": "COVID-19 Vaccine Moderna",
+      "marketingAuthorizationHolder": "Moderna Biotech"
+    }
+  },
+  "proof": {
+    "type": "BbsBlsSignature2020",
+    "created": "2021-02-18T23:01:59Z",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "kyesJtjITx/qsXTOuBpAu44e1UC9kjwqbEVyPqTiHL0pVPyaD/xeD0pEw/qBtr25SfrmMj3wXhCMfH77cc6+JgpgIaAnmR5wtTKGsxNm03wwlXf8LFZujjbw+Uf9Wm3aNO7rmAdrG3ec8e9VEQZeIw==",
+    "verificationMethod": "did:key:zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2#zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2"
+  }
+}

--- a/packages/jose/test/ghp/fixtures/vc-1.json
+++ b/packages/jose/test/ghp/fixtures/vc-1.json
@@ -1,0 +1,24 @@
+{
+  "@context": ["https://www.w3.org/2018/credentials/v1", "https://w3id.org/vaccination/v1", "https://w3id.org/security/bbs/v1"],
+  "id": "urn:uvci:af5vshde843jf831j128fj",
+  "type": ["VaccinationCertificate", "VerifiableCredential"],
+  "description": "COVID-19 Vaccination Certificate",
+  "name": "COVID-19 Vaccination Certificate",
+  "expirationDate": "2029-12-03T12:19:52Z",
+  "issuanceDate": "2019-12-03T12:19:52Z",
+  "issuer": "did:key:zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2",
+  "credentialSubject": {
+    "id": "urn:bnid:_:c14n2",
+    "type": "VaccinationEvent",
+    "batchNumber": "1183738569",
+    "countryOfVaccination": "NZ"
+  },
+  "proof": {
+    "type": "BbsBlsSignatureProof2020",
+    "created": "2021-02-18T23:04:28Z",
+    "nonce": "JNGovx4GGoi341v/YCTcZq7aLWtBtz8UhoxEeCxZFevEGzfh94WUSg8Ly/q+2jLqzzY=",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "AB0GQA//jbDwMgaIIJeqP3fRyMYi6WDGhk0JlGJc/sk4ycuYGmyN7CbO4bA7yhIW/YQbHEkOgeMy0QM+usBgZad8x5FRePxfo4v1dSzAbJwWjx87G9F1lAIRgijlD4sYni1LhSo6svptDUmIrCAOwS2raV3G02mVejbwltMOo4+cyKcGlj9CzfjCgCuS1SqAxveDiMKGAAAAdJJF1pO6hBUGkebu/SMmiFafVdLvFgpMFUFEHTvElUQhwNSp6vxJp6Rs7pOVc9zHqAAAAAI7TJuDCf7ramzTo+syb7Njf6ExD11UKNcChaeblzegRBIkg3HoWgwR0hhd4z4D5/obSjGPKpGuD+1DoyTZhC/wqOjUZ03J1EtryZrC+y1DD14b4+khQVLgOBJ9+uvshrGDbu8+7anGezOa+qWT0FopAAAAEG6p07ghODpi8DVeDQyPwMY/iu2Lh7x3JShWniQrewY2GbsACBYOPlkNNm/qSExPRMe2X7UPpdsxpUDwqbObye4EXfAabgKd9gCmj2PNdvcOQAi5rIuJSGa4Vj7AtKoW/2vpmboPoOu4IEM1YviupomCKOzhjEuOof2/y5Adfb8JUVidWqf9Ye/HtxnzTu0HbaXL7jbwsMNn5wYfZuzpmVQgEXss2KePMSkHcfScAQNglnI90YgugHGuU+/DQcfMoA0+JviFcJy13yERAueVuzrDemzc+wJaEuNDn8UiTjAdVhLcgnHqUai+4F6ONbCfH2B3ohB3hSiGB6C7hDnEyXFOO9BijCTHrxPv3yKWNkks+3JfY28m+3NO0e2tlyH71yDX0+F6U388/bvWod/u5s3MpaCibTZEYoAc4sm4jW03HFYMmvYBuWOY6rGGOgIrXxQjx98D0macJJR7Hkh7KJhMkwvtyI4MaTPJsdJGfv8I+RFROxtRM7RcFpa4J5wF/wQnpyorqchwo6xAOKYFqCqKvI9B6Y7Da7/0iOiWsjs8a4zDiYynfYavnz6SdxCMpHLgplEQlnntqCb8C3qly2s5Ko3PGWu4M8Dlfcn4TT8YenkJDJicA91nlLaE8TJbBgsvgyT+zlTsRSXlFzQc+3KfWoODKZIZqTBaRZMft3S/",
+    "verificationMethod": "did:key:zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2#zUC724vuGvHpnCGFG1qqpXb81SiBLu3KLSqVzenwEZNPoY35i2Bscb8DLaVwHvRFs6F2NkNNXRcPWvqnPDUd9ukdjLkjZd3u9zzL4wDZDUpkPAatLDGLEYVo8kkAzuAKJQMr7N2"
+  }
+}

--- a/packages/jose/test/ghp/fixtures/vp.json
+++ b/packages/jose/test/ghp/fixtures/vp.json
@@ -1,0 +1,24 @@
+{
+  "@context": ["https://www.w3.org/2018/credentials/v1"],
+  "type": ["VerifiablePresentation"],
+  "verifiableCredential": [],
+  "proof": {
+    "type": "Ed25519Signature2018",
+    "proofPurpose": "authentication",
+    "verificationMethod": "did:key:z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL#z6Mkgg342Ycpuk263R9d8Aq6MUaxPn1DDeHyGo38EefXmgDL",
+    "created": "2021-04-23T16:04:37.759497",
+    "challenge": "1f44d55f-f161-4938-a659-f8026467f126",
+    "jws": "eyJhbGciOiAiRWREU0EiLCAiYjY0IjogZmFsc2UsICJjcml0IjogWyJiNjQiXX0..qljm3LhN5vL-qv-4j3Hz6dF7Wgnx8boBAWJONrRAQNmvhBwUkI2_AEvDSbtNNTskz4i8vzzvLX4Ixl75RdoZCQ"
+  },
+  "presentation_submission": {
+    "id": "f9513f33-4ad4-4359-af91-783e052b5ed8",
+    "definition_id": "32f54163-7166-48f1-93d8-ff217bdb0653",
+    "descriptor_map": [
+      {
+        "id": "citizenship_input_1",
+        "format": "ldp_vp",
+        "path": "$.verifiableCredential[0]"
+      }
+    ]
+  }
+}

--- a/packages/jose/test/ghp/jwe.test.ts
+++ b/packages/jose/test/ghp/jwe.test.ts
@@ -1,0 +1,31 @@
+import test from 'ava'
+
+import {didcomm} from '../../dist/index.js'
+
+const k0 = {
+  id:
+    'did:example:123#zACHcwW82qt3JuD2Co21dHarqPoK4RYviAHW9x9xPjor9m4mBGiBCQUDtyMkAwUfQ6ogSR7GHBFe2tnz9Eenbe4PGn9r2c7cujfNo3HQuyQfc8Tfdk8LdoSTXeCA35RjrQoWcbbM',
+  type: 'JsonWebKey2020',
+  controller: 'did:example:123',
+  publicKeyJwk: {
+    kty: 'EC',
+    crv: 'P-384',
+    x: 'KVEDQVwV_1PDuIC1Ra5YNM1G1df-EdS81tAf9tM6Nwuk-W75JozY6uRW1DyiBq7u',
+    y: 'StxYyQarQ1Qi-hQxJDsDlc-ojVXq_NbxX_ZibzOTLNCIZ4cEEBBqFvRRfqPHObPY',
+  },
+  privateKeyJwk: {
+    kty: 'EC',
+    crv: 'P-384',
+    x: 'KVEDQVwV_1PDuIC1Ra5YNM1G1df-EdS81tAf9tM6Nwuk-W75JozY6uRW1DyiBq7u',
+    y: 'StxYyQarQ1Qi-hQxJDsDlc-ojVXq_NbxX_ZibzOTLNCIZ4cEEBBqFvRRfqPHObPY',
+    d: 'iKh5F1K7ukHt_XzMEpzk77redJ6SThfwWzJiylOwbdjqeIvIaEJud17fNb9X6kj3',
+  },
+}
+
+test('ECDH-ES encrypt / decrypt', async t => {
+  t.true('encrypt' in didcomm)
+  const m0 = 'It’s a dangerous business, Frodo, going out your door.'
+  const m0_jwe = await didcomm.encrypt(m0, k0.publicKeyJwk)
+  const m0_dec = await didcomm.decrypt(m0_jwe, k0.privateKeyJwk)
+  t.true(m0 === m0_dec)
+})

--- a/packages/jose/test/ghp/message.sanity.test.ts
+++ b/packages/jose/test/ghp/message.sanity.test.ts
@@ -1,0 +1,9 @@
+import test from 'ava'
+
+import * as fixture from './fixtures'
+
+test('assertions on json message structure', async t => {
+  t.true('credentialManifest' in fixture)
+  t.true(JSON.stringify(fixture.request_vp) === JSON.stringify(require('./fixtures/expected-request.json')))
+  t.true(JSON.stringify(fixture.submit_vp) === JSON.stringify(require('./fixtures/expected-submission.json')))
+})


### PR DESCRIPTION
This PR:

- Adds stubs for JWE encrypt / decrypt for ECDH-ES
- Adds DIDComm message fixtures for BBS+ Vaccination Certificate
- Adds Presentation Definition fixtures for BBS+ Vaccination Certificate
- Adds Credential Manifest fixtures for BBS+ Vaccination Certificate