### PR TITLE
DIDComm review - routing keys section

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -200,18 +200,20 @@ communicated by the `service` property as defined above.
 Before preparing a routed message, the sender encrypts the message for the
 recipient. Then, for each routing key in the `routingKeys` array in order, take
 the encrypted message, wrap it in a forward message (see below), and encrypt the
-forward message to the routing key. The newly encrypted message becomes the
-message to transmit to the listed `serviceEndpoint` or encrypted to the next
-routing key in the `routingKeys` array.
+forward message to the routing key.
+
+The process of wrapping the encrypted message in a forward message and
+encrypting it is repeated for each routing key in the array. The final encrypted
+message is transmitted to the listed `serviceEndpoint`.
 
 Forward message structure:
 
 ```json5
 {
     "type": "https://didcomm.org/routing/2.0/forward",
-    "to": ["did:example:somemediator#somekey"],
+    "to": ["did:example:somemediator#somekey"], // the routing key URI
     "body":{
-        "next": "did:example:123123123",
+        "next": "did:example:123123123", // the recipient of the encrypted package
     },
     "attachments": [
         {

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -224,7 +224,6 @@ Forward message structure:
 ```
 
 
-
 ### Establishing an HTTP(S) Connection
 
 In order to establish a new connection, Simply exchange a new message between parties. Knowing the DID of the other parties does not indicate any level of trust.

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -197,28 +197,29 @@ Routing Keys are used to enable message routing to agents unable to provide a
 direct service endpoint. Routing is arranged by the message recipient and
 communicated by the `service` property as defined above. 
 
-Before preparing a routed message, the sender encrypts the message for the
-recipient. Then, for each routing key in the `routingKeys` array in order, take
-the encrypted message, wrap it in a forward message (see below), and encrypt the
-forward message to the routing key.
+Before preparing a routed message, the sender creates an encrypted package by
+encrypting the message for the recipient. Then, for each routing key in the
+`routingKeys` array in order, take the encrypted package, wrap it in a forward
+message (see below), and encrypt the forward message to the routing key to
+create a new encrypted package.
 
-The process of wrapping the encrypted message in a forward message and
+The process of wrapping the encrypted package in a forward message and
 encrypting it is repeated for each routing key in the array. The final encrypted
-message is transmitted to the listed `serviceEndpoint`.
+package is transmitted to the listed `serviceEndpoint`.
 
 Forward message structure:
 
 ```json5
 {
     "type": "https://didcomm.org/routing/2.0/forward",
-    "to": ["did:example:somemediator#somekey"], // the routing key URI
+    "to": ["did:example:somemediator#somekey"], //the routing key URI
     "body":{
-        "next": "did:example:123123123", // the recipient of the encrypted package
+        "next": "did:example:123123123", //the recipient of the encrypted package
     },
     "attachments": [
         {
             "data": {
-            	"jwe": { } //jwe json structure of the message being forwarded
+            	"jwe": { } //jwe json structure of the encrypted package
         	}
         }
     ]

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -195,13 +195,14 @@ Both parties MUST have a `service` block containing the following properties:
 
 Routing Keys are used to enable message routing to agents unable to provide a
 direct service endpoint. Routing is arranged by the message recipient and
-communicated in the Service Endpoint as detailed above. 
+communicated by the `service` property as defined above. 
 
-For each DID key reference present in the `routingKeys` list in order, take the
-encrypted message, wrap it in a forward message as detailed below, and encrypt
-to the DID key reference. The newly encrypted message becomes the message to
-transmit to the listed `serviceEndpoint` or encrypted to the next Key in the
-`routingKeys` list.
+Before preparing a routed message, the sender encrypts the message for the
+recipient. Then, for each routing key in the `routingKeys` array in order, take
+the encrypted message, wrap it in a forward message (see below), and encrypt the
+forward message to the routing key. The newly encrypted message becomes the
+message to transmit to the listed `serviceEndpoint` or encrypted to the next
+routing key in the `routingKeys` array.
 
 Forward message structure:
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -193,13 +193,19 @@ Both parties MUST have a `service` block containing the following properties:
 
 #### Routing Keys
 
-Routing Keys are used to enable message routing to agents unable to provide a direct service endpoint. Routing is arranged by the message recipient and communicated in the Service Endpoint as detailed above. 
+Routing Keys are used to enable message routing to agents unable to provide a
+direct service endpoint. Routing is arranged by the message recipient and
+communicated in the Service Endpoint as detailed above. 
 
-For each DID key reference present in the `routingKeys` list in order, take the encrypted message, wrap it in a forward message as detailed below, and encrypt to the DID key reference. The newly encrypted message becomes the message to transmit to the listed `serviceEndpoint` or encrypted to the next Key in the `routingKeys` list.
+For each DID key reference present in the `routingKeys` list in order, take the
+encrypted message, wrap it in a forward message as detailed below, and encrypt
+to the DID key reference. The newly encrypted message becomes the message to
+transmit to the listed `serviceEndpoint` or encrypted to the next Key in the
+`routingKeys` list.
 
 Forward message structure:
 
-```jsonc
+```json5
 {
     "type": "https://didcomm.org/routing/2.0/forward",
     "to": ["did:example:somemediator#somekey"],
@@ -209,7 +215,7 @@ Forward message structure:
     "attachments": [
         {
             "data": {
-            	"jwe": { }//jwe json structure of the message being forwarded
+            	"jwe": { } //jwe json structure of the message being forwarded
         	}
         }
     ]


### PR DESCRIPTION
This PR adjusts line lengths and edits the routing keys section for clarity.

Certain assumptions were made that should be verified by those with more expertise. (@TelegramSam )

Some details of the process (e.g., what key to use when encrypting the original message, what value to use for each forward message `next` property) is still be missing. Suggestions for text that adds those details would be appreciated.