### PR TITLE
Editorial nit: to make "equivalence" between step 2 and WACI clearer and fix link

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -574,7 +574,7 @@ in can be functionally equivalent to the two-step request for a challenge token
 & callback URL described in the [challenge token
 section](https://identity.foundation/wallet-and-credential-interactions/#challenge-token-3).
 
-The response to the invite qR with presentation-proposal attached looks like this:
+The response to the invite QR with presentation-proposal attached looks like this:
 
 ```json
 {

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -563,12 +563,18 @@ suitable app.
 ### Step 2 - Send Message Proposing Presentation
 
 A "Propose Presentation" message, optional in many cases, is defined in [Aries
-RFC 0454](https://github.com/hyperledger/aries-rfcs/tree/master/features/0454-present-proof-v2#messages)
-and its Presentation Exchange "attachment" defined in
-[RFC 0510](https://github.com/hyperledger/aries-rfcs/blob/master/features/0510-dif-pres-exch-attach/README.md#propose-presentation-attachment-format).
+RFC
+0454](https://github.com/hyperledger/aries-rfcs/tree/master/features/0454-present-proof-v2#messages)
+and its Presentation Exchange "attachment" defined in [RFC
+0510](https://github.com/hyperledger/aries-rfcs/blob/master/features/0510-dif-pres-exch-attach/README.md#propose-presentation-attachment-format).
 It either initiates a Request/Share interaction or answers an earlier invitation
-to do so; it can be functionally equivalent to the request for a challenge token
-in the [challenge token section](#challenge-token-2) above:
+to do so. In the context of this flow, this response to the invitation
+establishes the same kind of connection that the WACI specification establishes
+in can be functionally equivalent to the two-step request for a challenge token
+& callback URL described in the [challenge token
+section](https://identity.foundation/wallet-and-credential-interactions/#challenge-token-3).
+
+The response to the invite qR with presentation-proposal attached looks like this:
 
 ```json
 {


### PR DESCRIPTION
this sentence previously linked to the challengeToken section of a different flow in the WACI spec, which was, at the time, pasted into this spec.  I reworded the "equivalence" to be more explanatory, and replaced the local anchor link with a direct link to the relevant section of the WACI spec.  Feel free to request changes, reject, etc., I'm not wed to it and apologies if I injected any opinions or dependencies or broken-link-risks, just trying to make comparisons explicit and n00b-friendly.