### PR TITLE
Added missing VerifiableCredential type to VCs

### DIFF
--- a/spec/v0.1/spec.md
+++ b/spec/v0.1/spec.md
@@ -783,6 +783,7 @@ In the following message structure, the issuer wants a Permanent Resident Card (
                      "@context":"https://www.w3.org/2018/credentials/v1",
                      "id":"https://eu.com/claims/DriversLicense",
                      "type":[
+                        "VerifiableCredential",
                         "EUDriversLicense"
                      ],
                      "issuer":"did:foo:123",
@@ -872,6 +873,7 @@ The User sends a [Credential Application message](https://identity.foundation/cr
                      ],
                      "id":"urn:uvci:af5vshde843jf831j128fj",
                      "type":[
+                        "VerifiableCredential",
                         "VaccinationCertificate",
                         "PermanentResidentCard"
                      ],
@@ -959,6 +961,7 @@ The Issuer sends a [Credential Fulfilment message](https://identity.foundation/c
                      "@context":"https://www.w3.org/2018/credentials/v1",
                      "id":"https://eu.com/claims/DriversLicense",
                      "type":[
+                        "VerifiableCredential",
                         "EUDriversLicense"
                      ],
                      "issuer":"did:foo:123",


### PR DESCRIPTION
Added the "VerifiableCredential" type to VCs, which is required by the VC spec (see https://www.w3.org/TR/vc-data-model/#types)